### PR TITLE
Allow either NA imputation or prevent imputation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,12 @@
   column is assumed to contain row IDs.
 * Added more useful error messages which provide both the date causing the
   error, and the associated ID. 
-
+* If `NULL` is given for `day.impute` or `month.impute` then
+  `fix_dates()` will error if there are any missing values for either day or
+  month respectively. If `NA` is given for `day.impute` or `month.impute` then
+  `fix_dates()` will impute NA for any missing values for either day or
+  month respectively   
+  
 # datefixR 0.1.1
 
 * First version of the package

--- a/R/fix_dates.R
+++ b/R/fix_dates.R
@@ -60,7 +60,8 @@ fix_dates <- function(df,
           {
             fixed.dates[i] <- fix_date(df[i, col.name],
                                        day.impute,
-                                       month.impute)
+                                       month.impute,
+                                       subject = df[i, id])
             },
           error = function(cond){
             message(paste0("Unable to resolve date for subject ",
@@ -69,15 +70,15 @@ fix_dates <- function(df,
                        df[i, col.name],
                        ")\n")
                  )
-            stop(cond)
-        })
+            stop(cond)}
+        )
       }
     df[, col.name] <- as.Date(fixed.dates)
     }
     df
 }
 
-fix_date <- function(date, day.impute, month.impute) {
+fix_date <- function(date, day.impute, month.impute, subject) {
 
   if (is.null(date) || is.na(date) || as.character(date) == "") {
     return(NA)
@@ -139,6 +140,12 @@ fix_date <- function(date, day.impute, month.impute) {
   
   if (is.na(day) || is.na(month)) {
     fixed_date <- NA
+    warning(paste0("NA imputed for subject ",
+                   subject,
+                   " (date: ",
+                   date,
+                   ")\n"),
+            call. = FALSE)
   } else { 
     fixed_date <- paste0(year, "-", month, "-", day)
   }

--- a/R/fix_dates.R
+++ b/R/fix_dates.R
@@ -87,7 +87,9 @@ fix_date <- function(date, day.impute, month.impute) {
 
   if (nchar(date) == 4) {
     # Just given year
-    year <- date; month <- month.impute; day <- day.impute
+    year <- date
+    month <- .imputemonth(month.impute)
+    day <- .imputeday(day.impute)
   } else{
     date_vec <- .separate_date(date)
     if (any(nchar(date_vec) > 4)) {
@@ -116,7 +118,7 @@ fix_date <- function(date, day.impute, month.impute) {
     }
     if (length(date_vec) < 3) {
       # ASSUME MM/YYYY, YYYY/MM
-      day <- day.impute
+      day <- .imputeday(day.impute) 
       if (nchar(date_vec[1]) == 4) {
       # Assume YYYY/MM
       year <- date_vec[1]; month <- date_vec[2]
@@ -134,7 +136,12 @@ fix_date <- function(date, day.impute, month.impute) {
     }
   }
   .checkoutput(day, month)
-  fixed_date <- paste0(year, "-", month, "-", day)
+  
+  if (is.na(day) || is.na(month)) {
+    fixed_date <- NA
+  } else { 
+    fixed_date <- paste0(year, "-", month, "-", day)
+  }
   fixed_date
 }
 
@@ -174,42 +181,68 @@ fix_date <- function(date, day.impute, month.impute) {
 }
 
 .checkday <- function(day.impute){
-  if (day.impute < 1 | day.impute > 28) {
-    stop("day.impute should be an integer between 1 and 28\n")
-  }
-  if (!(day.impute %% 1 == 0)) {
-    stop("day.impute should be an integer\n")
+  if (!is.na(day.impute) && !is.null(day.impute)) {
+    if (day.impute < 1 | day.impute > 28) {
+      stop("day.impute should be an integer between 1 and 28\n")
+    }
+    if (!(day.impute %% 1 == 0)) {
+      stop("day.impute should be an integer\n")
+    }
   }
   return()
 }
 
 .checkmonth <- function(month.impute){
-  if (month.impute < 1 | month.impute > 12) {
-    stop("month.impute should be an integer between 1 and 12\n")
-  }
-  if (!(month.impute %% 1 == 0)) {
-    stop("month.impute should be an integer\n")
+  if (!is.na(month.impute) && !is.null(month.impute)) {
+    if (month.impute < 1 | month.impute > 12) {
+      stop("month.impute should be an integer between 1 and 12\n")
+    }
+    if (!(month.impute %% 1 == 0)) {
+      stop("month.impute should be an integer\n")
+    }
   }
   return()
 }
 
 .checkoutput <- function(day, month){
-
-  if (as.numeric(month) > 12 | as.numeric(month) < 1) {
-    stop("Month not in expected range \n")
+  if (!is.na(month)) {
+    if (as.numeric(month) > 12 | as.numeric(month) < 1) {
+      stop("Month not in expected range \n")
+    }
   }
-  if (as.numeric(day) > 31 | as.numeric(day) < 1) {
-    stop("Day of the year not in expected range \n")
+  if (!is.na(day)) {
+    if (as.numeric(day) > 31 | as.numeric(day) < 1) {
+      stop("Day of the year not in expected range \n")
+    }
   }
   NULL
 }
 
 .convertimpute <- function(impute){
-  if (impute < 10) {
-    replacement <- paste0("0", impute)
+  if (!is.na(impute) && !is.null(impute)) {
+    if (impute < 10) {
+      replacement <- paste0("0", impute)
+    } else {
+      replacement <- as.character(impute)
+    }
   } else {
-    replacement <- as.character(impute)
+    replacement <- impute
   }
   replacement
 }
 
+.imputemonth <- function(month.impute){
+  if (is.null(month.impute)) {
+    stop("Missing month with no imputation value given \n")
+  } else {
+    month.impute
+  }
+}
+
+.imputeday <- function(day.impute){
+  if (is.null(day.impute)) {
+    stop("Missing day with no imputation value given \n")
+  } else {
+    day.impute
+  }
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,6 +19,7 @@ knitr::opts_chunk$set(
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/datefixR)](https://cran.r-project.org/package=datefixR)
 ![Top language](https://img.shields.io/github/languages/top/nathansam/datefixR)
 [![License: GPL-3](https://img.shields.io/badge/License-GPL3-green.svg)](https://opensource.org/licenses/GPL-3.0)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5655311.svg)](https://doi.org/10.5281/zenodo.5655311)
 <!-- badges: end -->
 
 `datefixR` is designed to standardize messy date data, such as dates

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ status](https://github.com/nathansam/datefixR/workflows/R-CMD-check/badge.svg)](
 language](https://img.shields.io/github/languages/top/nathansam/datefixR)
 [![License:
 GPL-3](https://img.shields.io/badge/License-GPL3-green.svg)](https://opensource.org/licenses/GPL-3.0)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5655311.svg)](https://doi.org/10.5281/zenodo.5655311)
 <!-- badges: end -->
 
 `datefixR` is designed to standardize messy date data, such as dates

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,23 @@
+citHeader("To cite datefixR in publications use:")
+
+year <- sub("-.*", "", packageDate("datefixR"))
+note <- sprintf("R package version %s", packageVersion("datefixR"))
+
+citEntry(
+  entry    = "Manual",
+  title    = "{datefixR}: Fix Really Messy Dates in {R}",
+  author   = as.person("Nathan Constantine-Cooke"),
+  year     = year,
+  url      = "https://CRAN.R-project.org/package=datefixR", 
+  doi      = "10.5281/zenodo.5655311",
+  note     = note,
+  textVersion = paste0("Constantine-Cooke, Nathan ",
+                       year,
+                       ". datefixR: Fix Really Messy Dates in R. ",
+                       note,
+                       ". DOI: 10.5281/zenodo.5655311. https://CRAN.R-project.org/package=datefixR")
+  )
+
+
+
+

--- a/tests/testthat/test_fix_dates.R
+++ b/tests/testthat/test_fix_dates.R
@@ -135,3 +135,38 @@ test_that("Error if day out of bounds", {
   expect_error(fix_dates(temp, "date"),
                "Day of the year not in expected range \n")
 })
+
+test_that("Error if day out of bounds", {
+  temp <- data.frame(id = 1, date = "34-12-1994")
+  
+  expect_error(fix_dates(temp, "date"),
+               "Day of the year not in expected range \n")
+})
+
+
+test_that("Imputing day with NA results in NA", {
+  temp <- data.frame(id = 1, date = "04-1994")
+  expect_equal(fix_dates(temp, "date", day.impute = NA ),
+               data.frame(id = 1, date = as.Date(NA)))
+})
+
+
+test_that("Imputing month with NA results in NA", {
+  temp <- data.frame(id = 1, date = "1994")
+  expect_equal(fix_dates(temp, "date", month.impute = NA ),
+               data.frame(id = 1, date = as.Date(NA)))
+})
+
+
+test_that("Error if imputing month with NULL", {
+  temp <- data.frame(id = 1, date = "1994")
+  expect_error(fix_dates(temp, "date", month.impute = NULL ),
+               "Missing month with no imputation value given \n")
+})
+
+test_that("Error if imputing day with NULL", {
+  temp <- data.frame(id = 1, date = "07-1994")
+  expect_error(fix_dates(temp, "date", day.impute = NULL ),
+               "Missing day with no imputation value given \n")
+})
+


### PR DESCRIPTION
* Setting `day.impute = NA` or `month.impute = NA` will result in NA if day or month is missing respectively in a date and a warning is issued. If `day.impute = NULL` or `month.impute = NULL` then the function will error if day or month is missing respectively in a date
* Add citation file
* Add Zenodo doi to README